### PR TITLE
feat(http): update openapi-fetch, support image uploads

### DIFF
--- a/.changeset/proud-students-rest.md
+++ b/.changeset/proud-students-rest.md
@@ -1,0 +1,6 @@
+---
+"bigrequest": patch
+"bigexec": patch
+---
+
+⚠️ BREAKING: Updates `openapi-fetch` dependency to latest version (`0.7.1`). All REST methods are now UPPERCASE (`GET()`, `POST()`, etc.)

--- a/packages/bigexec/src/index.ts
+++ b/packages/bigexec/src/index.ts
@@ -48,7 +48,7 @@ const promptAndValidateChannelSite = async (
 
   const bc = bigrequest.rest({ storeHash, accessToken });
 
-  const channelSiteRes = await bc.v3.post('/channels/{channel_id}/site', {
+  const channelSiteRes = await bc.v3.POST('/channels/{channel_id}/site', {
     params: {
       path: { channel_id: channelId },
       header: { 'Content-Type': 'application/json', Accept: 'application/json' },
@@ -124,7 +124,7 @@ const main = async () => {
 
   const bc = bigrequest.rest({ storeHash, accessToken });
 
-  const createChannelRes = await bc.v3.post('/channels', {
+  const createChannelRes = await bc.v3.POST('/channels', {
     body: {
       name: newChannelName,
       platform,
@@ -149,7 +149,7 @@ const main = async () => {
 
   await promptAndValidateChannelSite(storeHash, accessToken, channelId);
 
-  const createCITRes = await bc.v3.post('/storefront/api-token-customer-impersonation', {
+  const createCITRes = await bc.v3.POST('/storefront/api-token-customer-impersonation', {
     params: {
       header: {
         'Content-Type': 'application/json',

--- a/packages/bigrequest/README.md
+++ b/packages/bigrequest/README.md
@@ -47,7 +47,7 @@ const bc = bigrequest.rest({
 });
 
 // Use the REST client
-const product = await bc.v3.get('/catalog/products/{product_id}', {
+const product = await bc.v3.GET('/catalog/products/{product_id}', {
   params: {
     header: { Accept: 'application/json' },
     path: { product_id: 111 },
@@ -56,22 +56,62 @@ const product = await bc.v3.get('/catalog/products/{product_id}', {
 
 /**
  * product: {
- *   data: {
- *     id?: number | undefined;
- *     name: string;
- *     type: "physical" | "digital";
- *     sku?: string | undefined;
- *     ...
- *   } | undefined;
- *   errors: {
- *     status?: number | undefined;
- *     title?: string | undefined;
- *     type?: string | undefined;
- *     instance?: string | undefined;
- *   } | undefined;
+ *   data:
+ *     | {
+ *         data: {
+ *           id?: number | undefined;
+ *           name: string;
+ *           type: "physical" | "digital";
+ *           sku?: string | undefined;
+ *           ...
+ *         };
+ *         meta: {};
+ *       }
+ *     | undefined;
+ *   errors:
+ *     | {
+ *         status?: number | undefined;
+ *         title?: string | undefined;
+ *         type?: string | undefined;
+ *         instance?: string | undefined;
+ *       }
+ *     | undefined;
  *   response: Response;
  * }
  */
+
+// Creating an image using FormData (recommended)
+const categoryImage = await bc.v3.POST(
+  "/catalog/categories/{category_id}/image",
+  {
+    params: {
+      header: {
+        "Content-Type": "multipart/form-data",
+        Accept: "application/json",
+      },
+      path: { category_id: 11 },
+    },
+    body: {
+      image_file: "path/to/image.jpg",
+    },
+    bodySerializer(body) {
+      const fd = new FormData();
+
+      /**
+       * body: {
+       *   image_file: "path/to/image.jpg"
+       * }
+       */
+      for (const [k, v] of Object.entries(body)) {
+        const blob = new Blob([fs.readFileSync(v)]);
+
+        fd.append(k, blob, "DESIRED_FILE_NAME.jpg");
+      }
+
+      return fd;
+    },
+  }
+);
 ```
 
 ### OAuth

--- a/packages/bigrequest/package.json
+++ b/packages/bigrequest/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "^9.0.1",
-    "openapi-fetch": "^0.3.0",
+    "openapi-fetch": "^0.7.1",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,8 +65,8 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       openapi-fetch:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.7.1
+        version: 0.7.1
       zod:
         specifier: ^3.21.4
         version: 3.21.4
@@ -3134,8 +3134,8 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
-  /openapi-fetch@0.3.0:
-    resolution: {integrity: sha512-vB3OGyDNDZ+tRSUqsdEDcHeq+nKBn2At4dijht3V8W1HPLd/qvJJ4nmjarJaweuztZEniwi5RbzSlMAEvSYcTA==}
+  /openapi-fetch@0.7.1:
+    resolution: {integrity: sha512-yU2xMcPqk4mpgY03yXPsxbobDTTw0AGPzhv1i4dfELBrLonYMfLzQx2eGgdlY4b51GmnnAgWZE9FAnBbM9/NtA==}
     dev: false
 
   /openapi-typescript@6.4.0:


### PR DESCRIPTION
- ⚠️ BREAKING: All REST methods are now UPPERCASE (`GET()`, `POST()`, etc.)
- BigRequest now supports image uploads for `POST` requests (check new documentation)
- Updates `openapi-fetch` dependency to latest version (`0.7.1`)