### PR TITLE
fix(nightly): replace process code with output var

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,19 +28,18 @@ jobs:
         id: status
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
-            echo "working tree not clean, opening pr"
+            echo "changes=true" >> $GITHUB_OUTPUT
           else
-            echo "nothing to commit, working tree clean"
-            exit 1;
+            echo "changes=false" >> $GITHUB_OUTPUT
           fi
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Configure git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Set timestamp
         run: |
           raw_timestamp=$(date +"%Y%m%d-%H%M%S")
@@ -48,7 +47,7 @@ jobs:
 
           echo "timestamp=$timestamp" >> "$GITHUB_ENV"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Get latest commit hash from bigcommerce/api-specs
         run: |
           gh_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "https://api.github.com/repos/bigcommerce/api-specs/commits?per_page=1")
@@ -58,7 +57,7 @@ jobs:
 
           echo "sha=$most_recent_commit_short" >> "$GITHUB_ENV"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Create branch
         run: |
           branch_name="nightly-$timestamp"
@@ -66,11 +65,11 @@ jobs:
 
           echo "branch_name=$branch_name" >> "$GITHUB_ENV"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Stage changes
         run: git add .
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Commit changes
         run: |
           commit_message="[nightly] generate types against bigcommerce/api-specs@$sha"
@@ -78,18 +77,18 @@ jobs:
 
           echo "commit_message=$commit_message" >> "$GITHUB_ENV"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Push changes
         run: git push --set-upstream origin "$branch_name"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Write PR body
         run: |
           body="Types generated via scheduled GitHub Actions job against [bigcommerce/api-specs@\`$sha\`](https://github.com/bigcommerce/api-specs/tree/$sha)"
 
           echo "pr_body=$body" >> "$GITHUB_ENV"
 
-      - if: steps.status.outcome == 'success'
+      - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Open PR
         run: gh pr create --base main --title "$commit_message" --body "$pr_body"
         env:


### PR DESCRIPTION
- Replace process code with output variable to prevent nightly workflow from sending a failure report if no changes are introduced by `pnpm generate`