### PR TITLE
[nightly] generate types against bigcommerce/api-specs@2e9f35f

### DIFF
--- a/packages/bigrequest/src/generated/brands_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/brands_catalog.v3.ts
@@ -674,8 +674,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     responses: {
@@ -722,8 +720,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     requestBody: {
@@ -923,8 +919,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     responses: {
@@ -967,8 +961,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     responses: {
@@ -1018,8 +1010,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     requestBody: {
@@ -1231,8 +1221,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     requestBody?: {
@@ -1303,8 +1291,6 @@ export interface operations {
       };
       path: {
         brand_id: components["parameters"]["BrandIdParam"];
-        /** @description The ID of the `Brand` to which the resource belongs. */
-        brand_id: number;
       };
     };
     responses: {

--- a/packages/bigrequest/src/generated/categories_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/categories_catalog.v3.ts
@@ -652,6 +652,16 @@ export interface operations {
         include_fields?: string;
         /** @description Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded. */
         exclude_fields?: string;
+        /**
+         * @description Controls the sort order of the response, for example, `sort=name`.
+         *
+         * Allowed values:
+         * - `name`: sort categories in alphabetical order by category name.
+         * - `id`: sort in ascending order by category ID.
+         * - `parent_id`: sort in ascending order by the ID of the parent category.
+         * - `sort_order`: sort in ascending order by sort order value.
+         */
+        sort?: string;
       };
       header: {
         Accept: components["parameters"]["Accept"];
@@ -898,8 +908,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -944,8 +952,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     requestBody: {
@@ -1195,8 +1201,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1239,8 +1243,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1290,8 +1292,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     requestBody: {
@@ -1362,10 +1362,6 @@ export interface operations {
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1418,10 +1414,6 @@ export interface operations {
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     requestBody: {
@@ -1465,10 +1457,6 @@ export interface operations {
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1497,8 +1485,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     requestBody?: {
@@ -1569,8 +1555,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1600,8 +1584,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     responses: {
@@ -1633,8 +1615,6 @@ export interface operations {
       };
       path: {
         category_id: components["parameters"]["CategoryIdParam"];
-        /** @description The ID of the `Category` to which the resource belongs. */
-        category_id: number;
       };
     };
     requestBody?: {

--- a/packages/bigrequest/src/generated/currencies.v2.ts
+++ b/packages/bigrequest/src/generated/currencies.v2.ts
@@ -226,6 +226,12 @@ export interface operations {
    */
   getAllCurrencies: {
     parameters: {
+      query?: {
+        /** @description Specifies the page number in a limited (paginated) list of currencies. */
+        page?: number;
+        /** @description Controls the number of items per page in a limited (paginated) list of currencies. */
+        limit?: number;
+      };
       header: {
         Accept: components["parameters"]["Accept"];
       };

--- a/packages/bigrequest/src/generated/customers.v3.ts
+++ b/packages/bigrequest/src/generated/customers.v3.ts
@@ -63,7 +63,7 @@ export interface paths {
      * * attribute_value -- This is input as a string, regardless of the [Type](/docs/rest-management/customers/customer-attributes#create-a-customer-attribute).
      *
      * **Limits**
-     * * Limit of 10 concurrent requests
+     * * Create 20 customers over the span of an hour. Attempting to make more than 20 API calls will result in a `429` return status until the hour has lapsed.
      *
      * **Notes**
      *
@@ -313,7 +313,7 @@ export interface paths {
     put: operations["CustomersConsentByCustomerId_PUT"];
     parameters: {
       path: {
-        customerId: string;
+        customerId: components["parameters"]["customerId"];
       };
     };
   };
@@ -1707,7 +1707,7 @@ export interface operations {
    * * attribute_value -- This is input as a string, regardless of the [Type](/docs/rest-management/customers/customer-attributes#create-a-customer-attribute).
    *
    * **Limits**
-   * * Limit of 10 concurrent requests
+   * * Create 20 customers over the span of an hour. Attempting to make more than 20 API calls will result in a `429` return status until the hour has lapsed.
    *
    * **Notes**
    *
@@ -2352,7 +2352,6 @@ export interface operations {
   CustomersConsentByCustomerId_GET: {
     parameters: {
       path: {
-        customerId: string;
         customerId: components["parameters"]["customerId"];
       };
     };
@@ -2388,7 +2387,6 @@ export interface operations {
         "Content-Type"?: string;
       };
       path: {
-        customerId: string;
         customerId: components["parameters"]["customerId"];
       };
     };

--- a/packages/bigrequest/src/generated/product-modifiers_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/product-modifiers_catalog.v3.ts
@@ -1055,8 +1055,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         modifier_id: components["parameters"]["ModifierIdParam"];
-        /** @description The ID of the `Modifier`. */
-        modifier_id: number;
       };
     };
     responses: {
@@ -1096,8 +1094,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         modifier_id: components["parameters"]["ModifierIdParam"];
-        /** @description The ID of the `Modifier`. */
-        modifier_id: number;
       };
     };
     requestBody: {
@@ -1531,8 +1527,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         modifier_id: components["parameters"]["ModifierIdParam"];
-        /** @description The ID of the `Modifier`. */
-        modifier_id: number;
       };
     };
     responses: {

--- a/packages/bigrequest/src/generated/product-variant-options_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/product-variant-options_catalog.v3.ts
@@ -938,8 +938,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         option_id: components["parameters"]["OptionIdParam"];
-        /** @description The ID of the `Option`. */
-        option_id: number;
       };
     };
     responses: {
@@ -982,8 +980,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         option_id: components["parameters"]["OptionIdParam"];
-        /** @description The ID of the `Option`. */
-        option_id: number;
       };
     };
     requestBody: {
@@ -1419,8 +1415,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         option_id: components["parameters"]["OptionIdParam"];
-        /** @description The ID of the `Option`. */
-        option_id: number;
       };
     };
     responses: {

--- a/packages/bigrequest/src/generated/product-variants_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/product-variants_catalog.v3.ts
@@ -779,8 +779,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     responses: {
@@ -820,8 +818,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     requestBody: {
@@ -879,8 +875,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     responses: {
@@ -1041,10 +1035,6 @@ export interface operations {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     responses: {
@@ -1098,10 +1088,6 @@ export interface operations {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     requestBody: {
@@ -1146,10 +1132,6 @@ export interface operations {
         product_id: components["parameters"]["ProductIdParam"];
         variant_id: components["parameters"]["VariantIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
-        /** @description ID of the variant on a product, or on an associated Price List Record. */
-        variant_id: number;
       };
     };
     responses: {

--- a/packages/bigrequest/src/generated/products_catalog.v3.ts
+++ b/packages/bigrequest/src/generated/products_catalog.v3.ts
@@ -2879,8 +2879,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         image_id: components["parameters"]["ImageIdParam"];
-        /** @description The ID of the `Image` that is being operated on. */
-        image_id: number;
       };
     };
     responses: {
@@ -2924,8 +2922,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         image_id: components["parameters"]["ImageIdParam"];
-        /** @description The ID of the `Image` that is being operated on. */
-        image_id: number;
       };
     };
     requestBody: {
@@ -3034,8 +3030,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         image_id: components["parameters"]["ImageIdParam"];
-        /** @description The ID of the `Image` that is being operated on. */
-        image_id: number;
       };
     };
     responses: {
@@ -3207,8 +3201,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         id: components["parameters"]["VideoIdParam"];
-        /** @description The BigCommerce ID of the `Video` */
-        id: number;
       };
     };
     responses: {
@@ -3254,8 +3246,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         id: components["parameters"]["VideoIdParam"];
-        /** @description The BigCommerce ID of the `Video` */
-        id: number;
       };
     };
     requestBody: {
@@ -3341,8 +3331,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         id: components["parameters"]["VideoIdParam"];
-        /** @description The BigCommerce ID of the `Video` */
-        id: number;
       };
     };
     responses: {
@@ -3690,8 +3678,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         complex_rule_id: components["parameters"]["ComplexRuleIdParam"];
-        /** @description The ID of the `ComplexRule`. */
-        complex_rule_id: number;
       };
     };
     responses: {
@@ -3858,8 +3844,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         complex_rule_id: components["parameters"]["ComplexRuleIdParam"];
-        /** @description The ID of the `ComplexRule`. */
-        complex_rule_id: number;
       };
     };
     requestBody: {
@@ -4134,8 +4118,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         complex_rule_id: components["parameters"]["ComplexRuleIdParam"];
-        /** @description The ID of the `ComplexRule`. */
-        complex_rule_id: number;
       };
     };
     responses: {
@@ -4323,8 +4305,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         custom_field_id: components["parameters"]["CustomFieldIdParam"];
-        /** @description The ID of the `CustomField`. */
-        custom_field_id: number;
       };
     };
     responses: {
@@ -4370,8 +4350,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         custom_field_id: components["parameters"]["CustomFieldIdParam"];
-        /** @description The ID of the `CustomField`. */
-        custom_field_id: number;
       };
     };
     requestBody: {
@@ -4474,8 +4452,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         custom_field_id: components["parameters"]["CustomFieldIdParam"];
-        /** @description The ID of the `CustomField`. */
-        custom_field_id: number;
       };
     };
     responses: {
@@ -4669,8 +4645,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         bulk_pricing_rule_id: components["parameters"]["BulkPricingRuleIdParam"];
-        /** @description The ID of the `BulkPricingRule`. */
-        bulk_pricing_rule_id: number;
       };
     };
     responses: {
@@ -4719,8 +4693,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         bulk_pricing_rule_id: components["parameters"]["BulkPricingRuleIdParam"];
-        /** @description The ID of the `BulkPricingRule`. */
-        bulk_pricing_rule_id: number;
       };
     };
     requestBody: {
@@ -4833,8 +4805,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         bulk_pricing_rule_id: components["parameters"]["BulkPricingRuleIdParam"];
-        /** @description The ID of the `BulkPricingRule`. */
-        bulk_pricing_rule_id: number;
       };
     };
     responses: {
@@ -4998,8 +4968,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
       };
     };
     responses: {
@@ -5053,8 +5021,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
       };
     };
     requestBody: {
@@ -5098,8 +5064,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         metafield_id: components["parameters"]["MetafieldIdParam"];
-        /** @description The ID of the `Metafield`. */
-        metafield_id: number;
       };
     };
     responses: {
@@ -5328,8 +5292,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         review_id: components["parameters"]["ReviewIdParam"];
-        /** @description The ID of the `review` that is being operated on. */
-        review_id: number;
       };
     };
     responses: {
@@ -5413,8 +5375,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         review_id: components["parameters"]["ReviewIdParam"];
-        /** @description The ID of the `review` that is being operated on. */
-        review_id: number;
       };
     };
     /** @description A BigCommerce `ProductReview` object. */
@@ -5520,8 +5480,6 @@ export interface operations {
       path: {
         product_id: components["parameters"]["ProductIdParam"];
         review_id: components["parameters"]["ReviewIdParam"];
-        /** @description The ID of the `review` that is being operated on. */
-        review_id: number;
       };
     };
     responses: {

--- a/packages/bigrequest/src/generated/settings.v3.ts
+++ b/packages/bigrequest/src/generated/settings.v3.ts
@@ -147,6 +147,7 @@ export interface paths {
         Accept: components["parameters"]["Accept"];
       };
       path: {
+        /** @description Web Analytics Provider ID. */
         id: number;
       };
     };

--- a/packages/bigrequest/src/generated/themes.v3.ts
+++ b/packages/bigrequest/src/generated/themes.v3.ts
@@ -121,7 +121,6 @@ export interface paths {
           Accept: components["parameters"]["Accept"];
         };
         path: {
-          uuid: string;
           uuid: components["parameters"]["ThemeIdParam"];
         };
       };
@@ -144,9 +143,6 @@ export interface paths {
       };
       header: {
         Accept: components["parameters"]["Accept"];
-      };
-      path: {
-        uuid: string;
       };
     };
   };


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/api-specs@`2e9f35f`](https://github.com/bigcommerce/api-specs/tree/2e9f35f)