### PR TITLE
fix(external): move api spec file source of truth

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,9 +48,9 @@ jobs:
           echo "timestamp=$timestamp" >> "$GITHUB_ENV"
 
       - if: ${{ steps.status.outputs.changes == 'true' }}
-        name: Get latest commit hash from bigcommerce/api-specs
+        name: Get latest commit hash from bigcommerce/docs
         run: |
-          gh_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "https://api.github.com/repos/bigcommerce/api-specs/commits?per_page=1")
+          gh_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GH_TOKEN }}" "https://api.github.com/repos/bigcommerce/docs/commits?per_page=1")
 
           most_recent_commit=$(echo "$gh_response" | jq -r '.[0].sha')
           most_recent_commit_short=${most_recent_commit:0:7}
@@ -72,7 +72,7 @@ jobs:
       - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Commit changes
         run: |
-          commit_message="[nightly] generate types against bigcommerce/api-specs@$sha"
+          commit_message="[nightly] generate types against bigcommerce/docs@$sha"
           git commit -m "$commit_message"
 
           echo "commit_message=$commit_message" >> "$GITHUB_ENV"
@@ -84,7 +84,7 @@ jobs:
       - if: ${{ steps.status.outputs.changes == 'true' }}
         name: Write PR body
         run: |
-          body="Types generated via scheduled GitHub Actions job against [bigcommerce/api-specs@\`$sha\`](https://github.com/bigcommerce/api-specs/tree/$sha)"
+          body="Types generated via scheduled GitHub Actions job against [bigcommerce/docs@\`$sha\`](https://github.com/bigcommerce/docs/tree/$sha)"
 
           echo "pr_body=$body" >> "$GITHUB_ENV"
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pnpm i
 
 ### Automated Type Generation for the BigRequest HTTP Client
 
-The BigCommerce API is constantly changing. As a best effort to ensure that the types for the request client stay updated in response to changes in the BigCommerce Open API Specs repository, [a scheduled GitHub Action](.github/workflows/nightly.yml) runs once a night to re-generate types against [the latest version of the bigcommerce/api-specs repository](https://github.com/bigcommerce/api-specs/tree/main).
+The BigCommerce API is constantly changing. As a best effort to ensure that the types for the request client stay updated in response to changes in the BigCommerce Open API Specs repository, [a scheduled GitHub Action](.github/workflows/nightly.yml) runs once a night to re-generate types against [the latest version of the bigcommerce/docs repository](https://github.com/bigcommerce/docs/tree/main/reference).
 
 If changes are introduced during the GitHub Action workflow, the action will open a PR for review (example: [matthewvolk/bigrequest#30](https://github.com/matthewvolk/bigrequest/pull/30)).
 

--- a/packages/bigrequest/README.md
+++ b/packages/bigrequest/README.md
@@ -21,10 +21,8 @@ npm i bigrequest
 
 ## Usage
 
-> ⚠️ Typescript is highly recommended due to its autocompletion for request paths and options. If you are unable to use Typescript, you can find valid request paths to pass the client [in the BigCommerce OpenAPI Specifications repository](https://github.com/bigcommerce/api-specs/tree/main/reference).
-
 ```ts
-// Typescript (recommended)
+// Typescript
 import bigrequest from 'bigrequest';
 ```
 
@@ -80,38 +78,35 @@ const product = await bc.v3.GET('/catalog/products/{product_id}', {
  * }
  */
 
-// Creating an image using FormData (recommended)
-const categoryImage = await bc.v3.POST(
-  "/catalog/categories/{category_id}/image",
-  {
-    params: {
-      header: {
-        "Content-Type": "multipart/form-data",
-        Accept: "application/json",
-      },
-      path: { category_id: 11 },
+// Creating an image using FormData
+const categoryImage = await bc.v3.POST('/catalog/categories/{category_id}/image', {
+  params: {
+    header: {
+      'Content-Type': 'multipart/form-data',
+      Accept: 'application/json',
     },
-    body: {
-      image_file: "path/to/image.jpg",
-    },
-    bodySerializer(body) {
-      const fd = new FormData();
+    path: { category_id: 11 },
+  },
+  body: {
+    image_file: 'path/to/image.jpg',
+  },
+  bodySerializer(body) {
+    const fd = new FormData();
 
-      /**
-       * body: {
-       *   image_file: "path/to/image.jpg"
-       * }
-       */
-      for (const [k, v] of Object.entries(body)) {
-        const blob = new Blob([fs.readFileSync(v)]);
+    /**
+     * body: {
+     *   image_file: "path/to/image.jpg"
+     * }
+     */
+    for (const [k, v] of Object.entries(body)) {
+      const blob = new Blob([fs.readFileSync(v)]);
 
-        fd.append(k, blob, "DESIRED_FILE_NAME.jpg");
-      }
+      fd.append(k, blob, 'DESIRED_FILE_NAME.jpg');
+    }
 
-      return fd;
-    },
-  }
-);
+    return fd;
+  },
+});
 ```
 
 ### OAuth

--- a/packages/bigrequest/src/generate.mjs
+++ b/packages/bigrequest/src/generate.mjs
@@ -12,7 +12,7 @@ import openapiTS from 'openapi-typescript';
  */
 
 const ghOwner = 'bigcommerce';
-const ghRepoName = 'api-specs';
+const ghRepoName = 'docs';
 const ghRepoBranch = 'main';
 
 /**
@@ -114,7 +114,7 @@ async function generate() {
 
   /**
    * Generate type definitions for each Open API spec
-   * file retrieved from the api-specs GitHub
+   * file retrieved from the bigcommerce/docs GitHub
    * repository. The content for each file is stored
    * as a string in an array
    */


### PR DESCRIPTION
**As of December 27th, 2023, the public BigCommerce OpenAPI Spec File source of truth is now located at https://github.com/bigcommerce/docs.**

The bigcommerce/api-specs repository is archived and read only. 

**More info:** 
* https://github.com/bigcommerce/api-specs/releases/tag/move-contents-to-docs
* https://github.com/bigcommerce/api-specs?tab=readme-ov-file#bigcommerce-api-specifications