### PR TITLE
fix(types): fix possibly null type error

### DIFF
--- a/packages/bigrequest/src/generate.mjs
+++ b/packages/bigrequest/src/generate.mjs
@@ -158,30 +158,26 @@ async function generate() {
    * definitions
    */
 
-  const v2TypeDefinitionFiles = typeDefinitionYmlContents
-    .map((content, i) => {
-      if (content.includes('https://api.bigcommerce.com/stores/{store_hash}/v2')) {
-        return path.basename(specFilePathsAndUrls[i].filePath);
-      }
+  const v2TypeDefinitionFiles = typeDefinitionYmlContents.flatMap((content, i) => {
+    if (content.includes('https://api.bigcommerce.com/stores/{store_hash}/v2')) {
+      return path.basename(specFilePathsAndUrls[i].filePath);
+    }
 
-      return null;
-    })
-    .filter((n) => n);
+    return [];
+  });
 
   /**
    * Creates an array of yml file names for v3 type
    * definitions
    */
 
-  const v3TypeDefinitionFiles = typeDefinitionYmlContents
-    .map((content, i) => {
-      if (content.includes('https://api.bigcommerce.com/stores/{store_hash}/v3')) {
-        return path.basename(specFilePathsAndUrls[i].filePath);
-      }
+  const v3TypeDefinitionFiles = typeDefinitionYmlContents.flatMap((content, i) => {
+    if (content.includes('https://api.bigcommerce.com/stores/{store_hash}/v3')) {
+      return path.basename(specFilePathsAndUrls[i].filePath);
+    }
 
-      return null;
-    })
-    .filter((n) => n);
+    return [];
+  });
 
   /**
    * Create v2paths file


### PR DESCRIPTION
Typescript can't figure out that `.filter((n) => n)` will narrow the types of the arrays to remove `null`. This resulted in `v2TypeDefinitionFiles`/`v3TypeDefinitionFiles` having a type of `(string | null)[]`, which triggered type errors when later interpolating each of the values in the arrays into strings.

To fix this, we could define a custom type guard, but since this file is written in Javascript, that would add a number of (arguably) unnecessary JSDoc lines to the file. Instead, we can take advantage of `flatMap` to return an empty array if a file path is not found. When the array is flattened, the empty arrays will be removed, resulting in the desired final type of `string[]` instead of `(string | null)[]`.