### PR TITLE
[nightly] generate types against bigcommerce/docs@c89cc95

### DIFF
--- a/src/generated/carts.v3.ts
+++ b/src/generated/carts.v3.ts
@@ -84,6 +84,7 @@ export interface paths {
      * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
      * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
      * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+     * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
      */
     post: operations["createCartRedirectURL"];
     parameters: {
@@ -1347,6 +1348,13 @@ export interface components {
         })[];
       custom_items?: components["schemas"]["cart_PostCustomItem"];
     };
+    /** Redirect_urls_Post */
+    Redirect_urls_Post: {
+      query_params?: {
+          key?: string;
+          value?: string;
+        }[];
+    };
     /** Cart_Line_Item_Update_Post */
     Cart_Line_Item_Update_Post: {
       line_items?: unknown;
@@ -2088,6 +2096,7 @@ export interface operations {
    * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
    * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
    * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+   * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
    */
   createCartRedirectURL: {
     parameters: {
@@ -2097,6 +2106,11 @@ export interface operations {
       };
       path: {
         cartId: components["parameters"]["cartId"];
+      };
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["Redirect_urls_Post"];
       };
     };
     responses: {

--- a/src/generated/products_catalog.v3.ts
+++ b/src/generated/products_catalog.v3.ts
@@ -352,11 +352,16 @@ export interface paths {
      * **Required Fields**
      * - none
      *
+     * **Name-Value Pair Uniqueness**
+     * - Every name-value pair must be unique inside a product.
+     *
      * **Read-Only**
      * - id
      *
-     * **Note:**
-     * The default rate limit for this endpoint is 40 concurrent requests.
+     *  **Limits**
+     * - 200 custom fields per product limit.
+     * - 250 characters per custom field limit.
+     * - 40 concurrent requests default rate limit.
      */
     put: operations["updateProductCustomField"];
     /**
@@ -1929,6 +1934,8 @@ export interface components {
       gtin?: string;
       /** @description Manufacturer Part Number */
       mpn?: string;
+      /** @description the date when the Product had been imported */
+      date_last_imported?: string;
       /**
        * @description The total (cumulative) rating for the product.
        *
@@ -2707,9 +2714,11 @@ export interface operations {
         "date_modified:min"?: string;
         /** @description Filter items by date_last_imported. */
         date_last_imported?: string;
-        /** @description Filter items by date_last_imported. For example, `date_last_imported:max=2020-06-15`. */
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:not=2015-08-21T22%3A53%3A23%2B00%3A00`. */
+        "date_last_imported:not"?: string;
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:max=2015-08-21T22%3A53%3A23%2B00%3A00`. */
         "date_last_imported:max"?: string;
-        /** @description Filter items by date_last_imported. For example, `date_last_imported:min=2018-06-15`. */
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00`. */
         "date_last_imported:min"?: string;
         /** @description Filter items based on whether the product is currently visible on the storefront. */
         is_visible?: boolean;
@@ -3016,7 +3025,7 @@ export interface operations {
         brand_id?: number;
         /** @description Filter items by date_modified. For example `v3/catalog/products?date_modified:min=2018-06-15` */
         date_modified?: string;
-        /** @description Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2018-06-15` */
+        /** @description Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00` */
         date_last_imported?: string;
         /** @description Filter items by if visible on the storefront. */
         is_visible?: boolean;
@@ -4855,11 +4864,16 @@ export interface operations {
    * **Required Fields**
    * - none
    *
+   * **Name-Value Pair Uniqueness**
+   * - Every name-value pair must be unique inside a product.
+   *
    * **Read-Only**
    * - id
    *
-   * **Note:**
-   * The default rate limit for this endpoint is 40 concurrent requests.
+   *  **Limits**
+   * - 200 custom fields per product limit.
+   * - 250 characters per custom field limit.
+   * - 40 concurrent requests default rate limit.
    */
   updateProductCustomField: {
     parameters: {


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`c89cc95`](https://github.com/bigcommerce/docs/tree/c89cc95)