### PR TITLE
[nightly] generate types against bigcommerce/docs@575768e

### DIFF
--- a/src/generated/carts.v3.ts
+++ b/src/generated/carts.v3.ts
@@ -84,6 +84,7 @@ export interface paths {
      * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
      * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
      * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+     * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
      */
     post: operations["createCartRedirectURL"];
     parameters: {
@@ -1347,6 +1348,13 @@ export interface components {
         })[];
       custom_items?: components["schemas"]["cart_PostCustomItem"];
     };
+    /** Redirect_urls_Post */
+    Redirect_urls_Post: {
+      query_params?: {
+          key?: string;
+          value?: string;
+        }[];
+    };
     /** Cart_Line_Item_Update_Post */
     Cart_Line_Item_Update_Post: {
       line_items?: unknown;
@@ -2088,6 +2096,7 @@ export interface operations {
    * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
    * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
    * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+   * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
    */
   createCartRedirectURL: {
     parameters: {
@@ -2097,6 +2106,11 @@ export interface operations {
       };
       path: {
         cartId: components["parameters"]["cartId"];
+      };
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["Redirect_urls_Post"];
       };
     };
     responses: {

--- a/src/generated/marketing.v2.ts
+++ b/src/generated/marketing.v2.ts
@@ -9,7 +9,7 @@ export interface paths {
   "/coupons": {
     /**
      * Get All Coupons
-     * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. Optional filter parameters can be passed in.
+     * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. You can pass in optional filter parameters. We recommended using `?min_id=x&limit=y` to paginate through a large set of data because it offers better performance.
      *
      * ## Usage Notes
      *
@@ -704,7 +704,7 @@ export interface operations {
 
   /**
    * Get All Coupons
-   * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. Optional filter parameters can be passed in.
+   * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. You can pass in optional filter parameters. We recommended using `?min_id=x&limit=y` to paginate through a large set of data because it offers better performance.
    *
    * ## Usage Notes
    *

--- a/src/generated/product-variants_catalog.v3.ts
+++ b/src/generated/product-variants_catalog.v3.ts
@@ -27,7 +27,7 @@ export interface paths {
      * * 600 SKUs per product limit.
      * * 255 characters SKU length limit.
      *
-     * Variants need to be created one at a time using this endpoint. To use a variant array and create products and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) during the initial product creation.
+     * Variants need to be created one at a time using this endpoint. To use a variant array, create products, and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) endpoint during the initial product creation.
      */
     post: operations["createProductVariant"];
     parameters: {
@@ -1103,7 +1103,7 @@ export interface operations {
    * * 600 SKUs per product limit.
    * * 255 characters SKU length limit.
    *
-   * Variants need to be created one at a time using this endpoint. To use a variant array and create products and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) during the initial product creation.
+   * Variants need to be created one at a time using this endpoint. To use a variant array, create products, and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) endpoint during the initial product creation.
    */
   createProductVariant: {
     parameters: {

--- a/src/generated/products_catalog.v3.ts
+++ b/src/generated/products_catalog.v3.ts
@@ -352,11 +352,16 @@ export interface paths {
      * **Required Fields**
      * - none
      *
+     * **Name-Value Pair Uniqueness**
+     * - Every name-value pair must be unique inside a product.
+     *
      * **Read-Only**
      * - id
      *
-     * **Note:**
-     * The default rate limit for this endpoint is 40 concurrent requests.
+     *  **Limits**
+     * - 200 custom fields per product limit.
+     * - 250 characters per custom field limit.
+     * - 40 concurrent requests default rate limit.
      */
     put: operations["updateProductCustomField"];
     /**
@@ -825,7 +830,10 @@ export interface components {
     };
     /** productVariant_Full */
     productVariant_Full: WithRequired<components["schemas"]["productVariant_Base"] & {
+      /** @description Product ID */
       product_id?: number;
+      /** @description Variant ID */
+      id?: number;
       sku?: string;
       /** @description Array of option and option values IDs that make up this variant. Will be empty if the variant is the productʼs base variant. */
       option_values?: components["schemas"]["productVariantOptionValue_Full"][];
@@ -835,7 +843,7 @@ export interface components {
        */
       calculated_price?: number;
       calculated_weight?: number;
-    }, "sku">;
+    }, "sku" | "id" | "product_id">;
     /**
      * productVariant_Put_Product
      * @description The model for a PUT to update variants on a product.
@@ -1006,7 +1014,7 @@ export interface components {
     productImage_Put: {
       /** @description The unique numeric identifier for the product with which the image is associated. */
       product_id?: number;
-      /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+      /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
       url_zoom?: string;
       /** @description The standard URL for this image. By default, this is used for product-page images. */
       url_standard?: string;
@@ -1066,9 +1074,7 @@ export interface components {
      * product_Put
      * @description The model for a PUT to update a product.
      */
-    product_Put: components["schemas"]["product_Base"] & {
-      variants?: components["schemas"]["productVariant_Put_Product"][];
-    };
+    product_Put: components["schemas"]["product_Base"] & Record<string, never>;
     /**
      * metafield_Base
      * @description Metafield for products, categories, variants, and brands; the max number of metafields allowed on each is 250. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
@@ -1258,6 +1264,8 @@ export interface components {
       url?: string;
       /** @description Returns `true` if the URL has been changed from its default state (the auto-assigned URL that BigCommerce provides). */
       is_customized?: boolean;
+      /** @description Optional field. This field automatically creates a dynamic 301 redirect when a product URL change occurs with a PUT request. Existing dynamic redirects will automatically update to a new URL to avoid a loop. */
+      create_redirect?: boolean;
     };
     /**
      * bulkPricingRule_Full
@@ -1551,7 +1559,6 @@ export interface components {
       option_set_id?: number;
       /** @description Legacy template setting which controls if the option set shows up to the side of or below the product image and description. */
       option_set_display?: string;
-      variants?: components["schemas"]["productVariant_Full"][];
     };
     /**
      * productImage_Full
@@ -1562,7 +1569,7 @@ export interface components {
       id?: number;
       /** @description The unique numeric identifier for the product with which the image is associated. */
       product_id?: number;
-      /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+      /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
       url_zoom?: string;
       /** @description The standard URL for this image. By default, this is used for product-page images. */
       url_standard?: string;
@@ -1929,6 +1936,8 @@ export interface components {
       gtin?: string;
       /** @description Manufacturer Part Number */
       mpn?: string;
+      /** @description the date when the Product had been imported */
+      date_last_imported?: string;
       /**
        * @description The total (cumulative) rating for the product.
        *
@@ -2707,9 +2716,11 @@ export interface operations {
         "date_modified:min"?: string;
         /** @description Filter items by date_last_imported. */
         date_last_imported?: string;
-        /** @description Filter items by date_last_imported. For example, `date_last_imported:max=2020-06-15`. */
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:not=2015-08-21T22%3A53%3A23%2B00%3A00`. */
+        "date_last_imported:not"?: string;
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:max=2015-08-21T22%3A53%3A23%2B00%3A00`. */
         "date_last_imported:max"?: string;
-        /** @description Filter items by date_last_imported. For example, `date_last_imported:min=2018-06-15`. */
+        /** @description Filter items by date_last_imported. For example, `date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00`. */
         "date_last_imported:min"?: string;
         /** @description Filter items based on whether the product is currently visible on the storefront. */
         is_visible?: boolean;
@@ -3016,7 +3027,7 @@ export interface operations {
         brand_id?: number;
         /** @description Filter items by date_modified. For example `v3/catalog/products?date_modified:min=2018-06-15` */
         date_modified?: string;
-        /** @description Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2018-06-15` */
+        /** @description Filter items by date_last_imported. For example `v3/catalog/products?date_last_imported:min=2015-08-21T22%3A53%3A23%2B00%3A00` */
         date_last_imported?: string;
         /** @description Filter items by if visible on the storefront. */
         is_visible?: boolean;
@@ -3312,7 +3323,7 @@ export interface operations {
         "application/json": {
           /** @description The unique numeric identifier for the product with which the image is associated. */
           product_id?: number;
-          /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+          /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
           url_zoom?: string;
           /** @description The standard URL for this image. By default, this is used for product-page images. */
           url_standard?: string;
@@ -3346,7 +3357,7 @@ export interface operations {
           id?: number;
           /** @description The unique numeric identifier for the product with which the image is associated. */
           product_id?: number;
-          /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+          /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
           url_zoom?: string;
           /** @description The standard URL for this image. By default, this is used for product-page images. */
           url_standard?: string;
@@ -3388,7 +3399,7 @@ export interface operations {
               id?: number;
               /** @description The unique numeric identifier for the product with which the image is associated. */
               product_id?: number;
-              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
               url_zoom?: string;
               /** @description The standard URL for this image. By default, this is used for product-page images. */
               url_standard?: string;
@@ -3419,7 +3430,7 @@ export interface operations {
                * Must be sent as a multipart/form-data field in the request body. Limit of 8 MB per file.
                */
               image_file?: string;
-              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
               url_zoom?: string;
               /** @description The standard URL for this image. By default, this is used for product-page images. */
               url_standard?: string;
@@ -3557,7 +3568,7 @@ export interface operations {
               id?: number;
               /** @description The unique numeric identifier for the product with which the image is associated. */
               product_id?: number;
-              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
               url_zoom?: string;
               /** @description The standard URL for this image. By default, this is used for product-page images. */
               url_standard?: string;
@@ -3587,7 +3598,7 @@ export interface operations {
                * Must be sent as a `multipart/form-data` field in the request body. Limit of 8 MB per file.
                */
               image_file?: string;
-              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. */
+              /** @description The zoom URL for this image. By default, this is used as the zoom image on product pages when zoom images are enabled. You should provide an image smaller than 1280x1280; otherwise, the API returns a resized image. */
               url_zoom?: string;
               /** @description The standard URL for this image. By default, this is used for product-page images. */
               url_standard?: string;
@@ -4855,11 +4866,16 @@ export interface operations {
    * **Required Fields**
    * - none
    *
+   * **Name-Value Pair Uniqueness**
+   * - Every name-value pair must be unique inside a product.
+   *
    * **Read-Only**
    * - id
    *
-   * **Note:**
-   * The default rate limit for this endpoint is 40 concurrent requests.
+   *  **Limits**
+   * - 200 custom fields per product limit.
+   * - 250 characters per custom field limit.
+   * - 40 concurrent requests default rate limit.
    */
   updateProductCustomField: {
     parameters: {

--- a/src/generated/settings.v3.ts
+++ b/src/generated/settings.v3.ts
@@ -217,8 +217,6 @@ export interface paths {
     /**
      * Update Locale Settings
      * @description Updates global locale settings.
-     *
-     * Set a channel override by using the `channel_id` query parameter. To remove a channel override, set `null` for a field. The field then inherits the global value.
      */
     put: operations["updateSettingsLocale"];
   };
@@ -1607,9 +1605,6 @@ export interface operations {
    */
   getSettingsLocale: {
     parameters: {
-      query?: {
-        channel_id?: components["parameters"]["ChannelIdParam"];
-      };
       header: {
         Accept: components["parameters"]["Accept"];
       };
@@ -1628,14 +1623,9 @@ export interface operations {
   /**
    * Update Locale Settings
    * @description Updates global locale settings.
-   *
-   * Set a channel override by using the `channel_id` query parameter. To remove a channel override, set `null` for a field. The field then inherits the global value.
    */
   updateSettingsLocale: {
     parameters: {
-      query?: {
-        channel_id?: components["parameters"]["ChannelIdParam"];
-      };
       header: {
         Accept: components["parameters"]["Accept"];
         "Content-Type": components["parameters"]["ContentType"];


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`575768e`](https://github.com/bigcommerce/docs/tree/575768e)