### PR TITLE
[nightly] generate types against bigcommerce/docs@4d0d16b

### DIFF
--- a/src/generated/carts.v3.ts
+++ b/src/generated/carts.v3.ts
@@ -84,6 +84,7 @@ export interface paths {
      * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
      * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
      * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+     * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
      */
     post: operations["createCartRedirectURL"];
     parameters: {
@@ -1347,6 +1348,13 @@ export interface components {
         })[];
       custom_items?: components["schemas"]["cart_PostCustomItem"];
     };
+    /** Redirect_urls_Post */
+    Redirect_urls_Post: {
+      query_params?: {
+          key?: string;
+          value?: string;
+        }[];
+    };
     /** Cart_Line_Item_Update_Post */
     Cart_Line_Item_Update_Post: {
       line_items?: unknown;
@@ -2088,6 +2096,7 @@ export interface operations {
    * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
    * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
    * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
+   * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
    */
   createCartRedirectURL: {
     parameters: {
@@ -2097,6 +2106,11 @@ export interface operations {
       };
       path: {
         cartId: components["parameters"]["cartId"];
+      };
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["Redirect_urls_Post"];
       };
     };
     responses: {

--- a/src/generated/marketing.v2.ts
+++ b/src/generated/marketing.v2.ts
@@ -9,7 +9,7 @@ export interface paths {
   "/coupons": {
     /**
      * Get All Coupons
-     * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. Optional filter parameters can be passed in.
+     * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. You can pass in optional filter parameters. We recommended using `?min_id=x&limit=y` to paginate through a large set of data because it offers better performance.
      *
      * ## Usage Notes
      *
@@ -704,7 +704,7 @@ export interface operations {
 
   /**
    * Get All Coupons
-   * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. Optional filter parameters can be passed in.
+   * @description Returns a list of *Coupons*. Default sorting is by coupon/discount id, from lowest to highest. You can pass in optional filter parameters. We recommended using `?min_id=x&limit=y` to paginate through a large set of data because it offers better performance.
    *
    * ## Usage Notes
    *

--- a/src/generated/product-variants_catalog.v3.ts
+++ b/src/generated/product-variants_catalog.v3.ts
@@ -27,7 +27,7 @@ export interface paths {
      * * 600 SKUs per product limit.
      * * 255 characters SKU length limit.
      *
-     * Variants need to be created one at a time using this endpoint. To use a variant array and create products and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) during the initial product creation.
+     * Variants need to be created one at a time using this endpoint. To use a variant array, create products, and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) endpoint during the initial product creation.
      */
     post: operations["createProductVariant"];
     parameters: {
@@ -1103,7 +1103,7 @@ export interface operations {
    * * 600 SKUs per product limit.
    * * 255 characters SKU length limit.
    *
-   * Variants need to be created one at a time using this endpoint. To use a variant array and create products and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) during the initial product creation.
+   * Variants need to be created one at a time using this endpoint. To use a variant array, create products, and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) endpoint during the initial product creation.
    */
   createProductVariant: {
     parameters: {

--- a/src/generated/settings.v3.ts
+++ b/src/generated/settings.v3.ts
@@ -217,8 +217,6 @@ export interface paths {
     /**
      * Update Locale Settings
      * @description Updates global locale settings.
-     *
-     * Set a channel override by using the `channel_id` query parameter. To remove a channel override, set `null` for a field. The field then inherits the global value.
      */
     put: operations["updateSettingsLocale"];
   };
@@ -1607,9 +1605,6 @@ export interface operations {
    */
   getSettingsLocale: {
     parameters: {
-      query?: {
-        channel_id?: components["parameters"]["ChannelIdParam"];
-      };
       header: {
         Accept: components["parameters"]["Accept"];
       };
@@ -1628,14 +1623,9 @@ export interface operations {
   /**
    * Update Locale Settings
    * @description Updates global locale settings.
-   *
-   * Set a channel override by using the `channel_id` query parameter. To remove a channel override, set `null` for a field. The field then inherits the global value.
    */
   updateSettingsLocale: {
     parameters: {
-      query?: {
-        channel_id?: components["parameters"]["ChannelIdParam"];
-      };
       header: {
         Accept: components["parameters"]["Accept"];
         "Content-Type": components["parameters"]["ContentType"];


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`4d0d16b`](https://github.com/bigcommerce/docs/tree/4d0d16b)