### PR TITLE
[nightly] generate types against bigcommerce/docs@0b48895

### DIFF
--- a/.changeset/ten-cobras-visit.md
+++ b/.changeset/ten-cobras-visit.md
@@ -1,0 +1,5 @@
+---
+'bigrequest': patch
+---
+
+bigcommerce/docs#172

--- a/src/generated/themes.v3.ts
+++ b/src/generated/themes.v3.ts
@@ -478,6 +478,10 @@ export interface components {
       name?: string;
       /** @description Flag to identify private themes. */
       is_private?: boolean;
+      /** @description Indicates whether this theme is active on the storefront. */
+      is_active?: boolean;
+      /** @description The date-time of the last theme update. */
+      updated_at?: string;
     };
     /**
      * Activate
@@ -526,6 +530,10 @@ export interface components {
           name?: string;
           /** @description Flag to identify private themes. */
           is_private?: boolean;
+          /** @description Indicates whether this theme is active on the storefront. */
+          is_active?: boolean;
+          /** @description The date-time of the last theme update. */
+          updated_at?: string;
         }[];
       /**
        * Collection Meta


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`0b48895`](https://github.com/bigcommerce/docs/tree/0b48895)