### PR TITLE
[nightly] generate types against bigcommerce/docs@4bcd141

### DIFF
--- a/src/generated/categories_catalog.v3.ts
+++ b/src/generated/categories_catalog.v3.ts
@@ -1018,7 +1018,7 @@ export interface components {
     Accept: string;
     /** @description The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body. */
     ContentType: string;
-    /** @description Specifies the page number in a limited (paginated) list of products. */
+    /** @description Specifies the page number in a limited (paginated) list of results. */
     PageParam?: number;
     /**
      * @description Controls the sort order of the response, for example, `sort=name`.
@@ -1038,7 +1038,7 @@ export interface components {
     MetafieldNamespaceParam?: string;
     /** @description Filter based on comma-separated metafieldʼs namespaces. Could be used with vanilla `namespace` query parameter. */
     MetafieldNamespaceInParam?: string[];
-    /** @description Controls the number of items per page in a limited (paginated) list of products. */
+    /** @description Controls the number of items per page in a limited (paginated) list of results. */
     LimitParam?: number;
     /** @description Sort direction. Acceptable values are: `asc`, `desc`. */
     DirectionParam?: "asc" | "desc";

--- a/src/generated/orders.v3.ts
+++ b/src/generated/orders.v3.ts
@@ -1131,6 +1131,8 @@ export interface components {
       total_refund_amount?: components["schemas"]["Amount"];
       /** @example 1.95 */
       total_refund_tax_amount?: number;
+      /** @example 1.99 */
+      order_level_refund_amount?: number;
       /** @description Indicates rounding value to bring `refund_total` to an amount refundable with payment providers (in this case to 2 decimal places). */
       rounding?: number;
       adjustment?: components["schemas"]["AdjustmentAmount"];

--- a/src/generated/products_catalog.v3.ts
+++ b/src/generated/products_catalog.v3.ts
@@ -572,7 +572,7 @@ export interface paths {
      */
     get: operations["getProductsCategoryAssignments"];
     /**
-     * Create Products Category Assignments.
+     * Create Products Category Assignments
      * @description Creates products category assignments.
      */
     put: operations["createProductsCategoryAssignments"];
@@ -1810,8 +1810,6 @@ export interface components {
       product_tax_code?: string;
       /** @description An array of IDs for the categories to which this product belongs. When updating a product, if an array of categories is supplied, all product categories will be overwritten. Does not accept more than 1,000 ID values. */
       categories?: number[];
-      /** @description An array of channel IDs for the channels that have this product. You can provide an empty request, a single ID, or an array of IDs. */
-      channels?: unknown[];
       /** @description You can add a product to an existing brand during a product /PUT or /POST. Use either the `brand_id` or the `brand_name` field. The response body can include `brand_id`. */
       brand_id?: number;
       /**
@@ -2806,7 +2804,6 @@ export interface operations {
         direction?: components["parameters"]["DirectionParam"];
         sort?: components["parameters"]["SortParam"];
         "categories:in"?: components["parameters"]["CategoriesInParam"];
-        "channel_id:in"?: components["parameters"]["ChannelIdInParam"];
         "id:min"?: components["parameters"]["IdMinParam"];
         "id:max"?: components["parameters"]["IdMaxParam"];
         "id:greater"?: components["parameters"]["IdGreaterParam"];
@@ -5897,7 +5894,7 @@ export interface operations {
     };
   };
   /**
-   * Create Products Category Assignments.
+   * Create Products Category Assignments
    * @description Creates products category assignments.
    */
   createProductsCategoryAssignments: {

--- a/src/generated/scripts.v3.ts
+++ b/src/generated/scripts.v3.ts
@@ -352,6 +352,17 @@ export interface components {
       enabled?: boolean;
       /** @example 1 */
       channel_id?: number;
+      /**
+       * @description Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
+       *
+       * The hash is the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any SRI standard-supported algorithm, including SHA-256, SHA-384, and SHA-512. If you provide more than one hash, they will all be added to the `integrity` attribute in order, separated by whitespace.
+       *
+       * @example [
+       *   "sha384-DgtwqxoPLKnJSER+TUmSPIpE6ZbVb2ZZwR241HHiqJipLiZQPN/JkKX5xxrEHUTt",
+       *   "sha384-UiwrqEuzfCtJKLI+dXmPNOpE6ZvBh2IIqT371rJiqJxyKjZ6PP/JmSD5hdsEUPOl"
+       * ]
+       */
+      integrity_hashes?: string[];
     };
   };
   responses: never;


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`4bcd141`](https://github.com/bigcommerce/docs/tree/4bcd141)