### PR TITLE
[nightly] generate types against bigcommerce/docs@7a92b37

### DIFF
--- a/src/generated/brands_catalog.v3.ts
+++ b/src/generated/brands_catalog.v3.ts
@@ -805,6 +805,8 @@ export interface components {
     ExcludeFieldsQuery?: string[];
     /** @description Field name to sort by. */
     SortQuery?: "name";
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
   };
   requestBodies: never;
   headers: never;
@@ -1690,6 +1692,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
       header: {
         Accept: components["parameters"]["Accept"];

--- a/src/generated/carts.v3.ts
+++ b/src/generated/carts.v3.ts
@@ -82,7 +82,6 @@ export interface paths {
      * * Redirect URLs point to either a shared checkout domain or a channel-specific domain, depending on the storefront configuration.
      * * Once a redirect URL has been visited, it will be invalidated and cannot be used again.
      * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
-     * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
      * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
      * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
      */
@@ -1979,6 +1978,8 @@ export interface components {
     LimitParam?: number;
     /** @description Sort direction. Acceptable values are: `asc`, `desc`. */
     DirectionParam?: "asc" | "desc";
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
   };
   requestBodies: never;
   headers: never;
@@ -2103,7 +2104,6 @@ export interface operations {
    * * Redirect URLs point to either a shared checkout domain or a channel-specific domain, depending on the storefront configuration.
    * * Once a redirect URL has been visited, it will be invalidated and cannot be used again.
    * * If your application requires URLs to be visited more than once, consider generating a fresh one each time you need to restore a cart, and redirecting to the URL from your own application.
-   * * Redirect URLs can be generated only from carts that were created using the **REST Management API**.
    * * To restore a cart that was created on the storefront, either by a shopper or a Storefront API, first recreate the cart using the **REST Management API**.
    * * When redirecting the shopper, you can add a set of `query_params` to the URL. The `query_params` feature allows passing additional information to the redirect URL.
    */
@@ -2663,6 +2663,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
     };
     responses: {

--- a/src/generated/categories_catalog.v3.ts
+++ b/src/generated/categories_catalog.v3.ts
@@ -1018,7 +1018,7 @@ export interface components {
     Accept: string;
     /** @description The [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the request body. */
     ContentType: string;
-    /** @description Specifies the page number in a limited (paginated) list of products. */
+    /** @description Specifies the page number in a limited (paginated) list of results. */
     PageParam?: number;
     /**
      * @description Controls the sort order of the response, for example, `sort=name`.
@@ -1038,12 +1038,14 @@ export interface components {
     MetafieldNamespaceParam?: string;
     /** @description Filter based on comma-separated metafieldʼs namespaces. Could be used with vanilla `namespace` query parameter. */
     MetafieldNamespaceInParam?: string[];
-    /** @description Controls the number of items per page in a limited (paginated) list of products. */
+    /** @description Controls the number of items per page in a limited (paginated) list of results. */
     LimitParam?: number;
     /** @description Sort direction. Acceptable values are: `asc`, `desc`. */
     DirectionParam?: "asc" | "desc";
     /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
     IncludeFieldsParam?: string[];
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
     /** @description Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded. */
     ExcludeFieldsParam?: string[];
     /** @description Filter items by keywords found in the `name`, `description`, or `sku` fields, or in the brand name. */
@@ -2131,6 +2133,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
       header: {
         Accept: components["parameters"]["Accept"];

--- a/src/generated/channels.v3.ts
+++ b/src/generated/channels.v3.ts
@@ -1598,6 +1598,8 @@ export interface components {
     DirectionParam?: "asc" | "desc";
     /** @description Channels subresources that can be included in the response. */
     include?: "currencies";
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
     /** @description Filter items based on whether the channel is currently available for integration. Setting this query parameter to `true` will return channels with the status of `prelaunch`, `active` , `inactive`, and `connected`. Setting this query parameter to `false` will return channels with the status of `disconnected`, `archived`, `deleted`, and `terminated`. */
     available?: boolean;
     /** @description Filter items by a comma-separated list of statuses. */
@@ -2369,6 +2371,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
     };
     responses: {

--- a/src/generated/checkouts.v3.ts
+++ b/src/generated/checkouts.v3.ts
@@ -778,6 +778,12 @@ export interface components {
         /** @example 1 */
         pickup_method_id?: number;
       };
+      custom_shipping?: {
+        /** @example 12.9 */
+        price?: number;
+        /** @example custom shipping */
+        description?: string;
+      };
     };
     /** Coupon Code Request */
     CouponCodeRequest: {

--- a/src/generated/customers.v3.ts
+++ b/src/generated/customers.v3.ts
@@ -2208,6 +2208,8 @@ export interface components {
     LimitParam?: number;
     /** @description Sort direction. Acceptable values are: `asc`, `desc`. */
     DirectionParam?: "asc" | "desc";
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
   };
   requestBodies: never;
   headers: never;
@@ -3266,6 +3268,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
     };
     responses: {

--- a/src/generated/orders.v3.ts
+++ b/src/generated/orders.v3.ts
@@ -75,8 +75,9 @@ export interface paths {
      * * `store_v2_orders`
      * * `store_v2_transactions`
      *
-     * **Note:**
-     * Order refunds are processed consecutively. Processing synchronous refunds on an order are not yet supported.
+     * **Notes:**
+     * * Create a refund quote before performing a refund request to best avoid a `422` error. Check the refund quote's response body for the `refund_methods` array. The `amount` given in the array must match the `amount` used in the refund request body.
+     * * Order refunds are processed consecutively. Processing synchronous refunds on an order is not yet supported.
      */
     post: operations["createOrderRefundQuotes"];
     parameters: {
@@ -1131,6 +1132,8 @@ export interface components {
       total_refund_amount?: components["schemas"]["Amount"];
       /** @example 1.95 */
       total_refund_tax_amount?: number;
+      /** @example 1.99 */
+      order_level_refund_amount?: number;
       /** @description Indicates rounding value to bring `refund_total` to an amount refundable with payment providers (in this case to 2 decimal places). */
       rounding?: number;
       adjustment?: components["schemas"]["AdjustmentAmount"];
@@ -2127,6 +2130,8 @@ export interface components {
     LimitParam?: number;
     /** @description Sort direction. Acceptable values are: `asc`, `desc`. */
     DirectionParam?: "asc" | "desc";
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
   };
   requestBodies: never;
   headers: never;
@@ -2253,8 +2258,9 @@ export interface operations {
    * * `store_v2_orders`
    * * `store_v2_transactions`
    *
-   * **Note:**
-   * Order refunds are processed consecutively. Processing synchronous refunds on an order are not yet supported.
+   * **Notes:**
+   * * Create a refund quote before performing a refund request to best avoid a `422` error. Check the refund quote's response body for the `refund_methods` array. The `amount` given in the array must match the `amount` used in the refund request body.
+   * * Order refunds are processed consecutively. Processing synchronous refunds on an order is not yet supported.
    */
   createOrderRefundQuotes: {
     parameters: {
@@ -2786,6 +2792,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
     };
     responses: {

--- a/src/generated/product-variants_catalog.v3.ts
+++ b/src/generated/product-variants_catalog.v3.ts
@@ -1036,6 +1036,8 @@ export interface components {
     DirectionParam?: "asc" | "desc";
     /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
     IncludeFieldsParam?: string[];
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
     /** @description Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded. */
     ExcludeFieldsParam?: string[];
     /** @description A comma-separated list of IDs of products you want to request. For example, `?product_id:in=77,80,81`. */
@@ -2094,6 +2096,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
       header: {
         Accept: components["parameters"]["Accept"];

--- a/src/generated/products_catalog.v3.ts
+++ b/src/generated/products_catalog.v3.ts
@@ -572,7 +572,7 @@ export interface paths {
      */
     get: operations["getProductsCategoryAssignments"];
     /**
-     * Create Products Category Assignments.
+     * Create Products Category Assignments
      * @description Creates products category assignments.
      */
     put: operations["createProductsCategoryAssignments"];
@@ -1810,8 +1810,6 @@ export interface components {
       product_tax_code?: string;
       /** @description An array of IDs for the categories to which this product belongs. When updating a product, if an array of categories is supplied, all product categories will be overwritten. Does not accept more than 1,000 ID values. */
       categories?: number[];
-      /** @description An array of channel IDs for the channels that have this product. You can provide an empty request, a single ID, or an array of IDs. */
-      channels?: unknown[];
       /** @description You can add a product to an existing brand during a product /PUT or /POST. Use either the `brand_id` or the `brand_name` field. The response body can include `brand_id`. */
       brand_id?: number;
       /**
@@ -2684,6 +2682,8 @@ export interface components {
     SortParam?: "id" | "name" | "sku" | "price" | "date_modified" | "date_last_imported" | "inventory_level" | "is_visible" | "total_sold";
     /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
     IncludeFieldsParam?: string[];
+    /** @description Fields to include, in a comma-separated list. The ID and the specified fields will be returned. */
+    IncludeFieldsParamMetafields?: ("resource_id" | "key" | "value" | "namespace" | "permission_set" | "resource_type" | "description" | "owner_client_id" | "date_created" | "date_modified")[];
     /** @description Sub-resources to include on a product, in a comma-separated list. If `options` or `modifiers` is used, results are limited to 10 per page. The ID and the specified fields will be returned. */
     IncludeFieldsEnumParam?: ("variants" | "images" | "custom_fields" | "bulk_pricing_rules" | "primary_image" | "modifiers" | "options" | "videos")[];
     /** @description Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded. */
@@ -2806,7 +2806,6 @@ export interface operations {
         direction?: components["parameters"]["DirectionParam"];
         sort?: components["parameters"]["SortParam"];
         "categories:in"?: components["parameters"]["CategoriesInParam"];
-        "channel_id:in"?: components["parameters"]["ChannelIdInParam"];
         "id:min"?: components["parameters"]["IdMinParam"];
         "id:max"?: components["parameters"]["IdMaxParam"];
         "id:greater"?: components["parameters"]["IdGreaterParam"];
@@ -5897,7 +5896,7 @@ export interface operations {
     };
   };
   /**
-   * Create Products Category Assignments.
+   * Create Products Category Assignments
    * @description Creates products category assignments.
    */
   createProductsCategoryAssignments: {
@@ -6055,6 +6054,7 @@ export interface operations {
         namespace?: components["parameters"]["MetafieldNamespaceParam"];
         "namespace:in"?: components["parameters"]["MetafieldNamespaceInParam"];
         direction?: components["parameters"]["DirectionParam"];
+        include_fields?: components["parameters"]["IncludeFieldsParamMetafields"];
       };
     };
     responses: {

--- a/src/generated/scripts.v3.ts
+++ b/src/generated/scripts.v3.ts
@@ -352,6 +352,17 @@ export interface components {
       enabled?: boolean;
       /** @example 1 */
       channel_id?: number;
+      /**
+       * @description Array of [Subresource integrity (SRI) hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for external SRC scripts that lets browsers validate the contents of the script.
+       *
+       * The hash is the `integrity` attribute on the `script` tag. You can add up to five hashes for a script and generate them using any SRI standard-supported algorithm, including SHA-256, SHA-384, and SHA-512. If you provide more than one hash, they will all be added to the `integrity` attribute in order, separated by whitespace.
+       *
+       * @example [
+       *   "sha384-DgtwqxoPLKnJSER+TUmSPIpE6ZbVb2ZZwR241HHiqJipLiZQPN/JkKX5xxrEHUTt",
+       *   "sha384-UiwrqEuzfCtJKLI+dXmPNOpE6ZvBh2IIqT371rJiqJxyKjZ6PP/JmSD5hdsEUPOl"
+       * ]
+       */
+      integrity_hashes?: string[];
     };
   };
   responses: never;


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`7a92b37`](https://github.com/bigcommerce/docs/tree/7a92b37)