### PR TITLE
[nightly] generate types against bigcommerce/docs@8739e57

### DIFF
--- a/src/generated/orders.v2.oas2.ts
+++ b/src/generated/orders.v2.oas2.ts
@@ -271,7 +271,7 @@ export interface paths {
      * Acceptable values for `shipping_provider` include the following, and this list may be updated at any time:
      *  - `""`, an empty string
      *  - `auspost`
-     *  - `canadapost
+     *  - `canadapost`
      *  - `endicia`
      *  - `usps`
      *  - `fedex`
@@ -3067,7 +3067,7 @@ export interface operations {
    * Acceptable values for `shipping_provider` include the following, and this list may be updated at any time:
    *  - `""`, an empty string
    *  - `auspost`
-   *  - `canadapost
+   *  - `canadapost`
    *  - `endicia`
    *  - `usps`
    *  - `fedex`


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`8739e57`](https://github.com/bigcommerce/docs/tree/8739e57)