### PR TITLE
[nightly] generate types against bigcommerce/docs@587ab58

### DIFF
--- a/src/generated/price_lists.v3.ts
+++ b/src/generated/price_lists.v3.ts
@@ -537,7 +537,7 @@ export interface operations {
         /** @description Controls the number of items per page in a limited (paginated) list of products. */
         limit?: number;
         "id:in"?: number[];
-        "name:like"?: string[];
+        "name:like"?: string;
         "date_created:max"?: string;
         "date_created:min"?: string;
         "date_modified:max"?: string;


### PR DESCRIPTION
Types generated via scheduled GitHub Actions job against [bigcommerce/docs@`587ab58`](https://github.com/bigcommerce/docs/tree/587ab58)