### PR TITLE
docs: update readme with guidance on using --save-exact

### DIFF
--- a/.changeset/fuzzy-spoons-applaud.md
+++ b/.changeset/fuzzy-spoons-applaud.md
@@ -1,0 +1,5 @@
+---
+'bigrequest': patch
+---
+
+Update README with guidance on installing package using `--save-exact`

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ This module is available in two formats:
 
 ## Installation
 
+> **⚠️ Important ⚠️**
+> It's important to install this package with the `--save-exact` flag. Until this package reaches version `1.0.0`, there may be breaking changes released with patch/minor versions.
+
 ```sh
-npm i bigrequest
+npm i bigrequest --save-exact
 ```
 
 ## Usage


### PR DESCRIPTION
It's important to install this package with the `--save-exact` flag. Until this package reaches version `1.0.0`, there may be breaking changes released with patch/minor versions.